### PR TITLE
Region names and misc typo

### DIFF
--- a/STARTERKIT/README.md
+++ b/STARTERKIT/README.md
@@ -124,7 +124,7 @@ The Cog grid structure was setup with the intent of having a very minimalist sta
 
 #### Theme Regions
 
-The regions avaiable are standard with classic sidebar region, along with pre and post content areas. The intent is to allow for containers to go full-width and rely on the grid containers for inner Susy containers. 
+The regions available are standard with classic sidebar region, along with pre and post content areas. The intent is to allow for containers to go full-width and rely on the grid containers for inner Susy containers.
 
 ```
 [theme-name].info.yml

--- a/STARTERKIT/README.md
+++ b/STARTERKIT/README.md
@@ -132,11 +132,11 @@ The regions avaiable are standard with classic sidebar region, along with pre an
 regions:
   branding: Branding
   header: Header
-  pre_content: 'Pre Content'
+  pre_content: 'Pre content'
   content: Content
   sidebar_first: 'Sidebar first'
   sidebar_second: 'Sidebar second'
-  post_content: 'Post Content'
+  post_content: 'Post content'
   footer: Footer
 ```
 ![regions](http://content.screencast.com/users/BedimStudios/folders/Jing/media/8ad8ecf1-bb60-4292-80b0-115fae8daac0/00001643.png)

--- a/STARTERKIT/STARTERKIT.info.yml
+++ b/STARTERKIT/STARTERKIT.info.yml
@@ -8,9 +8,9 @@ libraries:
 regions:
   branding: Branding
   header: Header
-  pre_content: 'Pre Content'
+  pre_content: 'Pre content'
   content: Content
   sidebar_first: 'Sidebar first'
   sidebar_second: 'Sidebar second'
-  post_content: 'Post Content'
+  post_content: 'Post content'
   footer: Footer

--- a/cog.info.yml
+++ b/cog.info.yml
@@ -8,9 +8,9 @@ libraries:
 regions:
   branding: Branding
   header: Header
-  pre_content: Pre Content
+  pre_content: Pre content
   content: Content
   sidebar_first: 'Sidebar first'
   sidebar_second: 'Sidebar second'
-  post_content: Post Content
+  post_content: Post content
   footer: Footer

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -28,7 +28,7 @@
     </header>
     <!-- /header -->
 
-    <!-- ______________________ Pre Content _______________________ -->
+    <!-- ______________________ Pre content _______________________ -->
     {% if page.pre_content %}
         <div class="clearfix pre-content" id="pre-content">
             <div class="mq--t">
@@ -103,7 +103,7 @@
     </div>
     <!-- /main -->
 
-    <!-- ______________________ Post Content _______________________ -->
+    <!-- ______________________ Post content _______________________ -->
 
     {% if page.post_content %}
         <div class="clearfix post-content" id="post-content">


### PR DESCRIPTION
The "Pre content" and "Post content" region names should be sentence cased like the rest of the region names (and like Drupal's [User Interface Standards](https://www.drupal.org/docs/develop/user-interface-standards/interface-text) dictate). While making that change I noticed and fixed a little typo.