### PR TITLE
Fix undefined index: #entity_type in hook_preprocess_node()

### DIFF
--- a/STARTERKIT/STARTERKIT.theme
+++ b/STARTERKIT/STARTERKIT.theme
@@ -51,7 +51,7 @@ function STARTERKIT_preprocess_block(&$variables) {
  */
 function STARTERKIT_preprocess_node(&$variables) {
   // Helper variables for multiple nodes.
-  if ($variables['elements']['#entity_type']) {
+  if (!empty($variables['elements']['#entity_type'])) {
     $variables['attributes']['class'][] = Html::cleanCssIdentifier('entity--type-' . $variables['elements']['#entity_type']);
   }
 }

--- a/cog.theme
+++ b/cog.theme
@@ -51,7 +51,7 @@ function cog_preprocess_block(&$variables) {
  */
 function cog_preprocess_node(&$variables) {
   // Helper variables for multiple nodes.
-  if ($variables['elements']['#entity_type']) {
+  if (!empty($variables['elements']['#entity_type'])) {
     $variables['attributes']['class'][] = Html::cleanCssIdentifier('entity--type-' . $variables['elements']['#entity_type']);
   }
 }


### PR DESCRIPTION
Cog's `hook_preprocess_node()` implementation tries to access an array index without first testing for its presence, leading to a PHP notice. This fixes it.