### PR TITLE
Adding out of the box responsiveness for images

### DIFF
--- a/STARTERKIT/sass/base/_base.scss
+++ b/STARTERKIT/sass/base/_base.scss
@@ -64,6 +64,16 @@ a:visited {
 body p {
   margin: 3px 0 10px;
 }
+
+
+// Responsive Images
+
+img,
+svg {
+  max-width: 100%;
+  height: auto;
+}
+
 // Blockquote
 //
 // Markup: blockquote.hbs


### PR DESCRIPTION
Most responsive themes have this fix for images to make them by default responsive but not to exceed the maximum width of their original image. ( See Bartik: http://cgit.drupalcode.org/drupal/tree/core/themes/bartik/css/base/elements.css#n131 and Zen http://cgit.drupalcode.org/zen/tree/STARTERKIT/components/base/embedded/_embedded.scss#n25)