### PR TITLE
Prevent STARTERKIT from appearing on "Appearance" page

### DIFF
--- a/STARTERKIT/STARTERKIT.info.yml
+++ b/STARTERKIT/STARTERKIT.info.yml
@@ -2,6 +2,7 @@ name: Cog STARTERKIT
 type: theme
 description: 'Acquia D8 starter theme'
 core: 8.x
+hidden: true
 base theme: cog
 libraries:
   - STARTERKIT/fonts

--- a/cog-internals/cog.drush.inc
+++ b/cog-internals/cog.drush.inc
@@ -127,8 +127,9 @@ function drush_cog($machine_name = NULL, $name = NULL) {
     $info_strings['Read the included README.md on how to create a theme with cog.'] = $description;
   }
 
-  // Remove theme info added by Drupal.org.
+  // Remove unwanted theme info.
   $info_regexs = array(
+    array('pattern' => '/hidden: truen/', 'replacement' => ''),
     array('pattern' => '/\# Information added by Drupal\.org packaging script on [\d-]+\n/', 'replacement' => ''),
     array('pattern' => "/version: '[^']+'\n/", 'replacement' => ''),
     array('pattern' => '/datestamp: \d+\n/', 'replacement' => ''),


### PR DESCRIPTION
STARTERKIT should never be installed as such, but it appears as an installable theme on the "Appearance" page. Let's hide it.