### PR TITLE
Fixed tiny textareas

### DIFF
--- a/STARTERKIT/sass/base/_form.scss
+++ b/STARTERKIT/sass/base/_form.scss
@@ -30,7 +30,6 @@ textarea {
   font-size: 0.875em;
   margin: 0 0 1em;
   padding: 0.5em;
-  height: 2.3125em;
   width: auto;
   box-sizing: border-box;
   transition: box-shadow 0.45s, border-color 0.45s ease-in-out;


### PR DESCRIPTION
Textareas are silly small. Not sure why we set the height at all.
![unnamed image 1](https://cloud.githubusercontent.com/assets/1984514/21913143/4529ad48-d8df-11e6-9e9d-9e8d712f3b9c.png)
