### PR TITLE
Removing the sidebar logic in cog.theme as it duplicates STARTERKIT.

### DIFF
--- a/cog.theme
+++ b/cog.theme
@@ -11,19 +11,6 @@ use Drupal\Component\Utility\Html;
  * Implements hook_preprocess_html().
  */
 function cog_preprocess_html(&$variables) {
-  // Body classes for sidebars.
-  if (isset($variables['page']['sidebar_first']) && isset($variables['page']['sidebar_second'])) {
-    $variables['attributes']['class'][] = Html::cleanCssIdentifier('body-sidebars-both');
-  }
-  elseif (isset($variables['page']['sidebar_first'])) {
-    $variables['attributes']['class'][] = Html::cleanCssIdentifier('body-sidebars-first');
-  }
-  elseif (isset($variables['page']['sidebar_second'])) {
-    $variables['attributes']['class'][] = Html::cleanCssIdentifier('body-sidebars-second');
-  }
-  else {
-    $variables['attributes']['class'][] = Html::cleanCssIdentifier('body-sidebars-none');
-  }
   $system_path = \Drupal::service('path.current')->getPath();
   $page_path = explode('/', $system_path)[1];
   if (!empty($page_path)) {


### PR DESCRIPTION
When the same sidebar logic is in cog.theme, renaming the sidebar regions in your custom theme causes cog to always add the `body-sidebars-none` class to the body. This messes up layouts.