### PR TITLE
Removing Gulp Plumber from compile-sass task.

### DIFF
--- a/STARTERKIT/gulp-tasks/compile-sass.js
+++ b/STARTERKIT/gulp-tasks/compile-sass.js
@@ -12,11 +12,6 @@ module.exports = function (gulp, plugins, options) {
     return gulp.src([
       options.sass.files
     ])
-      .pipe(plugins.plumber({
-        errorHandler: function (e) {
-          this.emit('end');
-        }
-      }))
       .pipe(plugins.sourcemaps.init())
       .pipe(plugins.sassGlob())
       .pipe(plugins.sass({
@@ -28,7 +23,6 @@ module.exports = function (gulp, plugins, options) {
         cascade: false
       }))
       .pipe(plugins.sourcemaps.write())
-      .pipe(plugins.plumber.stop())
       .pipe(gulp.dest(options.sass.destination));
   });
 };


### PR DESCRIPTION
Gulp Plumber is supressing sass compile errors causing builds to fail silently.