### PR TITLE
Proof of concept for Drush integration.

### DIFF
--- a/STARTERKIT/gulp-tasks/drush.js
+++ b/STARTERKIT/gulp-tasks/drush.js
@@ -1,6 +1,6 @@
 /**
  * @file
- * Task: Watch.
+ * Task: Drush.
  */
 
 /* global module */

--- a/STARTERKIT/gulp-tasks/drush.js
+++ b/STARTERKIT/gulp-tasks/drush.js
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * Task: Watch.
+ */
+
+/* global module */
+
+module.exports = function (gulp, plugins, options) {
+  'use strict';
+
+  var exec = require('child_process').exec;
+
+  gulp.task('drush:cache-clear', function (cb) {
+    if (options.drush.alias) {
+      return exec('drush ' + options.drush.alias + ' cache-clear css-js', function (err, stdout, stderr) {
+        cb(err);
+      });
+    }
+    plugins.util.log('Drush alias not configured. Skipping cache-clear.');
+    cb();
+  });
+
+  gulp.task('drush:cache-rebuild', function (cb) {
+    if (options.drush.alias) {
+      return exec('drush ' + options.drush.alias + ' cache-rebuild', function (err, stdout, stderr) {
+        cb(err);
+      });
+    }
+    plugins.util.log('Drush alias not configured. Skipping cache-rebuild.');
+    cb();
+  });
+
+};

--- a/STARTERKIT/gulp-tasks/watch.js
+++ b/STARTERKIT/gulp-tasks/watch.js
@@ -8,7 +8,7 @@
 module.exports = function (gulp, plugins, options) {
   'use strict';
 
-  gulp.task('watch', ['watch:sass', 'watch:styleguide', 'watch:js']);
+  gulp.task('watch', ['watch:sass', 'watch:styleguide', 'watch:js', 'watch:twig']);
 
   gulp.task('watch:js', function () {
     return gulp.watch([
@@ -29,6 +29,17 @@ module.exports = function (gulp, plugins, options) {
       plugins.runSequence(
         'compile:sass',
         'minify:css',
+        'browser-sync:reload'
+      );
+    });
+  });
+
+  gulp.task('watch:twig', function () {
+    return gulp.watch([
+      options.twig.files
+    ], function () {
+      plugins.runSequence(
+        'drush:cache-rebuild',
         'browser-sync:reload'
       );
     });

--- a/STARTERKIT/gulpfile.js
+++ b/STARTERKIT/gulpfile.js
@@ -94,7 +94,8 @@ var paths = {
     destination: 'js/dist'
   },
   images: 'img/',
-  styleGuide: 'styleguide'
+  styleGuide: 'styleguide',
+  templates: 'templates/'
 };
 
 // These are passed to each task.
@@ -135,6 +136,11 @@ var options = {
     destination: path.join(paths.scripts.destination)
   },
 
+  // ----- Twig ----- //
+  twig: {
+    files: paths.templates + '**/*.twig'
+  },
+
   // ----- Images ----- //
   images: {
     files: paths.images + '**/*.{png,gif,jpg,svg}',
@@ -153,7 +159,13 @@ var options = {
         'gulp-tasks/**/*'
       ]
     }
+  },
 
+  // ----- Drush ----- //
+  // add your local drush alias here to enable the gulp watch:twig task
+  // to automatically run a drush cache-rebuild.
+  drush: {
+    // alias: '@local.example.com'
   },
 
   // ----- KSS Node ----- //
@@ -184,6 +196,7 @@ require('./gulp-tasks/compile-sass')(gulp, plugins, options);
 require('./gulp-tasks/compile-js')(gulp, plugins, options);
 require('./gulp-tasks/compile-styleguide')(gulp, plugins, options);
 require('./gulp-tasks/default')(gulp, plugins, options);
+require('./gulp-tasks/drush')(gulp, plugins, options);
 require('./gulp-tasks/lint-js')(gulp, plugins, options);
 require('./gulp-tasks/lint-css')(gulp, plugins, options);
 require('./gulp-tasks/minify-css')(gulp, plugins, options);


### PR DESCRIPTION
As mentioned in #96, this is some basic configuration for triggering a `drush cache-rebuild` on template changes as part of the `gulp watch` task.

The drush alias requirement means this doesn't work out of the box. Leaving it to the discretion of @aellison and @jenter what to do with it.