### PR TITLE
Place sub-theme customisation options command in context

### DIFF
--- a/STARTERKIT/README.md
+++ b/STARTERKIT/README.md
@@ -24,11 +24,9 @@ The Cog theme is set up to utilize the `base => sub-theme` relationship. The ste
 
 * In your `themes/` directory create the `contrib/` and `custom/` directories
 * Download Cog into the `themes/contrib` folder and enable using `drush en cog`
-* Create the sub-theme with `drush cog "MyTheme"`
+* Create the sub-theme with `drush cog "MyTheme"` (if you'd like to customize, first run `drush help cog` to see available options)
 * Enable your new `MyTheme` theme with `drush en mytheme` which is located in `themes/custom`
 * Set `MyTheme` as your default theme `drush config-set system.theme default mytheme`
-
-Available options for creating your new theme `drush help cog`
 
 ### Setup Local Development
 


### PR DESCRIPTION
The first time I set up a Cog sub-theme I only realised that one could customise the sub-theme creation, after I'd created it, because the help text appeared out of context (after the bulleted list). Moving it closer to the initial 'drush cog "MyTheme"' command instruction should allow people to decide whether or not they'd like to customise before actually running the command. 