### PR TITLE
COG-00: POC KSS Style Guide Menu

### DIFF
--- a/STARTERKIT/gulpfile.js
+++ b/STARTERKIT/gulpfile.js
@@ -168,7 +168,9 @@ var options = {
       path.relative(paths.styleGuide, paths.styles.destination + 'styles.css'),
       path.relative(paths.styleGuide, paths.styles.destination + 'style-guide-only/kss-only.css')
     ],
-    js: [],
+    js: [
+      path.relative(paths.styleGuide, paths.styles.source + 'style-guide-only/kss-only.js')
+    ],
     homepage: 'style-guide-only/homepage.md',
     title: 'Living Style Guide'
   },

--- a/STARTERKIT/sass/style-guide-only/kss-only.js
+++ b/STARTERKIT/sass/style-guide-only/kss-only.js
@@ -1,0 +1,26 @@
+const doc = document;
+
+doc.addEventListener("DOMContentLoaded",()=>{
+
+  function insertBefore(el, referenceNode) {
+    referenceNode.parentNode.insertBefore(el, referenceNode);
+  }
+
+  function openToggle(trigger, target) {
+    trigger.addEventListener('click', () => {
+      target.classList.toggle('open');  
+      trigger.classList.toggle('open');  
+    });
+  }
+
+  const navTarget = doc.querySelector('nav.kss-nav');
+  navTarget.classList.add('open');  
+
+  const navTrigger = doc.createElement('div');
+  navTrigger.className = "kss-nav__trigger open";
+  navTrigger.innerHTML = '<a href="#">menu</a>';
+
+  insertBefore(navTrigger, navTarget);
+  openToggle(navTrigger, navTarget);
+
+});

--- a/STARTERKIT/sass/style-guide-only/kss-only.scss
+++ b/STARTERKIT/sass/style-guide-only/kss-only.scss
@@ -6,11 +6,219 @@
 // [id^="kssref-layouts-"] [class^="layout-"][class*="__"] {
 //   outline: 1px dotted color('grey');
 // }
-
 div.kss-modifier__wrapper {
   > * {
     // float: left;
     width: 100%;
     position: relative;
+  }
+}
+
+// KSS STYLE CUSTOM OVERRIDES
+
+// ------------------------------------------------------------------------------
+// Layout and page background
+// ------------------------------------------------------------------------------
+
+#kss-node {
+  .kss-main {
+    @media screen and (min-width: 769px) {
+      width: 100%;
+      margin-left: 0;
+      padding: 0 30px;
+    }
+  }
+
+  .kss-sidebar {
+    z-index: 10;
+    border-bottom: 0;
+    position: relative;
+    width: auto;
+    height: auto;
+    overflow: auto;
+    padding: 0;
+    background-image: none;
+    box-shadow: none;
+  }
+}
+
+// ------------------------------------------------------------------------------
+// Sidebar-area components
+// ------------------------------------------------------------------------------
+
+#kss-node {
+  margin-top: 70px;
+
+  header.kss-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 70px;
+    padding: 0 30px;
+    margin-top: 0;
+    border-bottom: 1px solid;
+    border-color: #979797;
+    background-color: #fff;
+    z-index: 15;
+
+    h1 {
+      margin: 0;
+      line-height: 70px;
+      font-weight: 300;
+      font-size: 2em;
+    }
+  }
+
+  nav.kss-nav {
+    position: fixed;
+    top: 70px;
+    bottom: 0;
+    right: 0;
+    width: 330px;
+    overflow-y: scroll;
+    background: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    text-shadow: 2px 2px 6px #000;
+    font-size: 1.3333em;
+    margin-top: 0;
+    z-index: 20;
+    height: 0;
+    transition: height 0.3s;
+
+    &.open {
+      height: calc(100vh - 70px);
+    }
+  }
+
+  .kss-nav__trigger {
+    width: auto;
+    height: 20px;
+    top: 24px;
+    position: fixed;
+    z-index: 25;
+    right: 40px;
+    text-align: right;
+    text-transform: uppercase;
+    color: #619ce1;
+    font-weight: 900;
+
+    & a {
+      color: #619ce1;
+    }
+
+    &::after {
+      content: ' +';
+      display: inline-block;
+      width: 1rem;
+      text-align: right;
+      font-size: 20px;
+      transition: all 0.3s;
+      position: absolute;
+      top: -2px;
+    }
+
+    &.open::after {
+      transform: rotate(45deg);
+      top: -5px;
+      font-size: 24px;
+      width: 1.25rem;
+    }
+
+    &:hover {
+      cursor: pointer;
+      text-decoration: underline;
+
+      & a {
+        color: #619ce1;
+      }
+    }
+  }
+
+  ul.kss-nav__menu {
+    margin: 0;
+    padding: 0;
+  }
+
+  li.kss-nav__menu-item {
+    padding: 15px 30px;
+    border-bottom: 1px solid #6c6c6c;
+    display: list-item;
+    padding-right: 0;
+  }
+
+  a.kss-nav__menu-link,
+  a.kss-nav__menu-link:link,
+  a.kss-nav__menu-link:visited,
+  a.kss-nav__menu-link:hover,
+  a.kss-nav__menu-link:active {
+    color: #fff;
+    text-decoration: none;
+    transition: color 0.3s;
+  }
+
+  a.kss-nav__menu-link:hover {
+    color: #aaa;
+    cursor: pointer;
+  }
+
+  span.kss-nav__ref {
+    color: #a0cafb;
+    font-size: 0.8em;
+    padding-right: 10px;
+
+    &::after {
+      display: none;
+    }
+  }
+
+  ul.kss-nav__menu-child {
+    display: block;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  ul.kss-nav__menu-child li.kss-nav__menu-item {
+    padding: 7px 20px;
+    font-size: 0.8em;
+    border: none;
+  }
+
+  .kss-nav__menu-link {
+    // position: relative;
+    // display: inline-block;
+
+    &::before {
+      content: ' ';
+      position: absolute;
+      left: -20px;
+      width: 0;
+      height: 100%;
+      background-color: rgba(#000, 0);
+    }
+
+    &.is-in-viewport::before {
+      background-color: #999;
+      width: 10px;
+      transition: background-color 0.3s;
+      height: 10px;
+      border-radius: 100px;
+      margin-top: 7px;
+    }
+  }
+}
+
+// ------------------------------------------------------------------------------
+// Content-area components
+// ------------------------------------------------------------------------------
+#kss-node {
+  .kss-section {
+    max-width: 100%;
+    padding-top: 50px;
+
+    &:first-child {
+      padding-top: 0;
+    }
   }
 }


### PR DESCRIPTION
This is a proof of concept for a less invasive menu for the style guide that I decided to resurrect from my Ghosts of MBOs Past since we're talking about including the KSS option in Cog 2. 

This is totally usable to try out locally and critique for functionality and design but we would want to do this with a custom build ([Issue #43](https://github.com/acquia-pso/cog/issues/43)). Right now I'm just overriding the default build with the existing kss-only.scss partial and I added a slightly gross kss-only.js where I add the menu trigger with JS. The styles would be pretty easy to move over to a custom build since I kept them in the same structure as the default KSS styles.