### PR TITLE
Fix npm install on NFS mounts.

### DIFF
--- a/STARTERKIT/package.json
+++ b/STARTERKIT/package.json
@@ -59,7 +59,7 @@
   "//": "The postinstall script is needed to work-around this Drupal core bug: https://www.drupal.org/node/2329453",
   "scripts": {
     "postinstall": "find node_modules/ -name '*.info' -type f -delete",
-    "install-tools": "npm install --force",
+    "install-tools": "npm install",
     "uninstall-tools": "rm -r node_modules;",
     "build": "gulp",
     "build:dev": "gulp build:dev",


### PR DESCRIPTION
For whatever reason, running npm install with the `--force` flag causes it to compile node-gyp / node-sass from source, which fails on NFS mounts (i.e. inside DrupalVM).

@sarahjean says we probably don't need this flag, I agree.

Diving into the git history, it looks like we originally added the force flag to work with _yarn_, not npm: https://github.com/acquia-pso/cog/pull/11

When we converted back from yarn to npm, it seems like we kept the flag without really considering why it was there: https://github.com/acquia-pso/cog/pull/100

As a side benefit of removing `--force`, npm install is soooo much faster now, especially with a warm cache.