### PR TITLE
Add back run sequence so that css minify is run after sass compile.

### DIFF
--- a/STARTERKIT/gulp-tasks/build.js
+++ b/STARTERKIT/gulp-tasks/build.js
@@ -7,22 +7,27 @@
 
 module.exports = function (gulp, plugins, options) {
   'use strict';
+  plugins.runSequence.options.showErrorStackTrace = false;
 
-  gulp.task('build', [
-    'compile:sass',
-    'minify:css',
-    'compile:styleguide',
-    'lint:js-gulp',
-    'lint:js-with-fail',
-    'lint:css-with-fail'
-  ]);
+  gulp.task('build', function(cb) {
+    plugins.runSequence(
+      'compile:sass',
+      ['minify:css',
+        'compile:styleguide'],
+      ['lint:js-gulp',
+        'lint:js-with-fail',
+        'lint:css-with-fail'],
+      cb);
+  });
 
-  gulp.task('build:dev', [
-    'compile:sass',
-    'minify:css',
-    'compile:styleguide',
-    'lint:js-gulp',
-    'lint:js',
-    'lint:css'
-  ]);
+  gulp.task('build:dev', function(cb) {
+    plugins.runSequence(
+      'compile:sass',
+      ['minify:css',
+        'compile:styleguide'],
+      ['lint:js-gulp',
+        'lint:js',
+        'lint:css'],
+      cb);
+  });
 };


### PR DESCRIPTION
Fix for https://github.com/acquia-pso/cog/issues/137