### PR TITLE
Human friendly name ifix

### DIFF
--- a/STARTERKIT/STARTERKIT.info.yml
+++ b/STARTERKIT/STARTERKIT.info.yml
@@ -1,4 +1,4 @@
-name: Cog STARTERKIT
+name: Cog Sub-theme Starter Kit
 type: theme
 description: 'Acquia D8 starter theme'
 core: 8.x


### PR DESCRIPTION
Update starterkit so that human friendly name is the same as what is given to drush.