### PR TITLE
Form element template add classy js classes for webform conditional fields

### DIFF
--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -46,9 +46,11 @@
 #}
 {%
   set classes = [
+    'js-form-item',
     'form-item',
     'js-form-type-' ~ type|clean_class,
     'form-type-' ~ type|clean_class,
+    'js-form-item-' ~ name|clean_class,
     'form-item-' ~ name|clean_class,
     title_display not in ['after', 'before'] ? 'form-no-label',
     disabled == 'disabled' ? 'form-disabled',


### PR DESCRIPTION
Webform conditional fields needs "js-form-item" & "js-form-item-FIELD" in order to work.
Basically I have updated the template with the latest version of the one that implements the Classy theme