### PR TITLE
cog.info.yml missing required base theme property

### DIFF
--- a/cog.info.yml
+++ b/cog.info.yml
@@ -1,6 +1,7 @@
 name: Cog
 type: theme
 description: 'An Acquia-maintained base theme.'
+base theme: stable
 package: Core
 core: 8.x
 libraries:


### PR DESCRIPTION
As of Drupal 8.8, the `base theme` property must be explicitly defined for all themes: https://www.drupal.org/node/3066038

In Drupal 8.8, this throws a deprecation warning (which breaks unit tests for any projects running in a codebase containing Cog, which is how I found this)

In Drupal 9, it will throw an error.

This also can't be easily worked around by patching via Composer, because of how the Drupal packaging process modifies the info.yml file.