### PR TITLE
Add core_version_requirement to declare compatibility with Drupal 9

### DIFF
--- a/cog.info.yml
+++ b/cog.info.yml
@@ -4,6 +4,7 @@ description: 'An Acquia-maintained base theme.'
 base theme: stable
 package: Core
 core: 8.x
+core_version_requirement: '^8 || ^9'
 libraries:
   - cog/lib
 regions:


### PR DESCRIPTION
Right now, Cog cannot even be required into a Drupal 9 code base. This is a problem for all projects using ORCA, because BLT requires Cog. To fix this, let's add a core_version_requirement key to Cog's info file which declares compatibility with both Drupal 8 and Drupal 9. Once this is merged and pushed to drupal.org, we'll be able to install Cog on Drupal 9 (or at least require it into a Drupal 9 project).