### PR TITLE
Fix starterkit's Composer name

### DIFF
--- a/starterkit/composer.json
+++ b/starterkit/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "drupal/starterkit",
+    "name": "drupal/cog-starterkit",
     "type": "drupal-theme",
     "description": "Acquia D8 starter theme",
     "license": "GPL-2.0-or-later"


### PR DESCRIPTION
This fixes a namespacing issue on Drupal.org.