### PR TITLE
Add D9 readiness ORCA job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   global:
     - ORCA_SUT_NAME=drupal/cog
     - ORCA_SUT_BRANCH=8.x-1.x
-    - ORCA_VERSION=master
+    - ORCA_VERSION=dev-master
     - ORCA_TELEMETRY_ENABLE=TRUE
 
 matrix:
@@ -34,14 +34,16 @@ matrix:
     - { name: "Isolated test w/ dev package versions", env: ORCA_JOB=ISOLATED_DEV }
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
+    - { name: "D9 readiness test", php: "7.3", env: ORCA_JOB=D9_READINESS}
     # Custom job.
     - { name: "Gulp test", env: COG_GULP_TEST=true }
   allow_failures:
     - env: ORCA_JOB=INTEGRATED_DEV
     - env: ORCA_JOB=CORE_NEXT
+    - { php: "7.3", env: ORCA_JOB=D9_READINESS }
 
 before_install:
-  - git clone --branch ${ORCA_VERSION} --depth 1 https://github.com/acquia/orca.git ../orca
+  - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
 
 install: ../orca/bin/travis/install.sh


### PR DESCRIPTION
This PR is mandatory unless this branch is not intended to survive to Drupal 9--in which, it may be closed unmerged. Thanks.