### PR TITLE
Require D9 readiness CI job to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ matrix:
   allow_failures:
     - env: ORCA_JOB=INTEGRATED_DEV
     - env: ORCA_JOB=CORE_NEXT
-    - { php: "7.3", env: ORCA_JOB=D9_READINESS }
 
 before_install:
   - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   global:
     - ORCA_SUT_NAME=drupal/cog
     - ORCA_SUT_BRANCH=8.x-1.x
-    - ORCA_VERSION=dev-master
+    - ORCA_VERSION=^2
     - ORCA_TELEMETRY_ENABLE=TRUE
 
 matrix:


### PR DESCRIPTION
This removes the Drupal 9 readiness ORCA job from allowed failures (and incidentally changes the followed ORCA version to the 2.x major to prevent unexpected failures when the next version is released).